### PR TITLE
Update auth.ts to support "@azure/msal-browser": "^3.1.0"

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -14,7 +14,7 @@ export type MaybeAccount = AccountInfo | null
  * MSAL instance
  */
 export const msal = new PublicClientApplication(config)
-
+await msal.initialize()
 /**
  * Auth service
  */


### PR DESCRIPTION
See here for more info:

https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/errors.md#native_broker_called_before_initialize

I tried to add the line after
// start msal
and before
await msal.andleRedirectPromise()
but that didn't work with me, so I added it after  export const msal = new ...
and that did work fine.

Please review as I am not 100% sure if this is correct. I'm also not using TS.